### PR TITLE
refactor: 카드 재발급 관련 구글시트 코드 리포지토리 패턴 적용

### DIFF
--- a/src/entities/card-reissue.entity.ts
+++ b/src/entities/card-reissue.entity.ts
@@ -1,0 +1,11 @@
+export class CardReissue {
+  idx: number | undefined;
+  user_id: number;
+  login_id: string;
+  apply_date: Date;
+  requestd: boolean;
+  issued: boolean;
+  picked: boolean;
+  origin_card_id: string;
+  new_card_id: string;
+}

--- a/src/reissue/reissue.module.ts
+++ b/src/reissue/reissue.module.ts
@@ -4,17 +4,22 @@ import { ReissueController } from './reissue.controller';
 import { UserCardRepository } from './repository/mysql/user-card-no.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserInfo } from 'src/entities/user-info.entity';
-import { UtilsModule } from 'src/utils/utils.module';
+import { CardReissueRepository } from './repository/googleApi/card-reissue.repository';
 
 const userCardRepo = {
   provide: 'IUserCardRepository',
   useClass: UserCardRepository,
 };
 
+const cardReissueRepo = {
+  provide: 'ICardReissueRepository',
+  useClass: CardReissueRepository,
+};
+
 @Module({
-  imports: [TypeOrmModule.forFeature([UserInfo]), UtilsModule],
+  imports: [TypeOrmModule.forFeature([UserInfo])],
   exports: [ReissueService],
   controllers: [ReissueController],
-  providers: [userCardRepo, ReissueService],
+  providers: [userCardRepo, cardReissueRepo, ReissueService],
 })
 export class ReissueModule {}

--- a/src/reissue/reissue.service.ts
+++ b/src/reissue/reissue.service.ts
@@ -109,17 +109,7 @@ export class ReissueService {
       origin_card_id: initialCardNo,
       new_card_id: '',
     };
-    try {
-      //await this.googleApi.appendValues(data);
-      await this.cardReissueRepository.save(data);
-    } catch (error) {
-      this.logger.error(
-        `@reissueRequest) failed to request for new card issuance for ${user.login}: ${error.message}`,
-      );
-      throw new ServiceUnavailableException(
-        `카드 재발급 신청 구글스프레드 시트에 업데이트 실패: ${error.message}`,
-      );
-    }
+   await this.cardReissueRepository.save(data);
     try {
       const jandiData = {
         request: 'request',

--- a/src/reissue/repository/googleApi/card-reissue.repository.ts
+++ b/src/reissue/repository/googleApi/card-reissue.repository.ts
@@ -1,0 +1,109 @@
+import { Inject, Logger } from '@nestjs/common';
+import { ICardReissueRepository } from '../interface/card-reissue.repository.interface';
+import { ConfigService } from '@nestjs/config';
+import { sheets, auth } from '@googleapis/sheets';
+import { CardReissue } from 'src/entities/card-reissue.entity';
+
+export class CardReissueRepository implements ICardReissueRepository {
+  private logger = new Logger(CardReissueRepository.name);
+
+  gsKey: string;
+  gsEmail: string;
+  gsRange: string;
+  gsSheetId: string;
+  gsScope: string[];
+
+  constructor(@Inject(ConfigService) private configService: ConfigService) {
+    this.gsScope = ['https://www.googleapis.com/auth/spreadsheets'];
+    this.gsKey = this.configService.get<string>('googleCardApi.key');
+    this.gsEmail = this.configService.get<string>('googleCardApi.email');
+    this.gsRange = this.configService.get<string>('googleCardApi.range');
+    this.gsSheetId = this.configService.get<string>(
+      'googleCardApi.spreadsheetId',
+    );
+  }
+
+  private convToKST(date: Date): string {
+    const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+    const requestedAt = new Date(date.getTime() + KR_TIME_DIFF)
+      .toISOString()
+      .replace(/T/, ' ')
+      .replace(/\..+/, '');
+    return requestedAt;
+  }
+
+  private authorize(): any {
+    const googleAuth = new auth.JWT({
+      email: this.gsEmail,
+      key: this.gsKey,
+      scopes: this.gsScope,
+    });
+    return googleAuth;
+  }
+
+  async findByUserId(user_id: number): Promise<CardReissue[]> {
+    const auth = this.authorize();
+    let result = [];
+    try {
+      const sheet = sheets('v4');
+      const allCardReissues = await sheet.spreadsheets.values.get({
+        auth: auth,
+        spreadsheetId: this.gsSheetId,
+        range: this.gsRange,
+      });
+      result = allCardReissues.data.values;
+    } catch (e) {
+      this.logger.error(e.message);
+    }
+    return result
+      .map((value, index) => ({
+        idx: index + 1,
+        user_id: value[0],
+        login_id: value[1],
+        apply_date: new Date(value[2]),
+        requestd: !!value[3],
+        issued: !!value[4],
+        picked: !!value[5],
+        origin_card_id: value[6] ? value[6] : '',
+        new_card_id: value[7] ? value[7] : '',
+      }))
+      .filter((result) => result.user_id == user_id);
+  }
+
+  async save(data: CardReissue): Promise<void> {
+    const auth = this.authorize();
+    const option = 'RAW';
+    const range = data.idx
+      ? this.gsRange + `!A${data.idx}:H${data.idx}`
+      : this.gsRange;
+    const value = [
+      data.user_id,
+      data.login_id,
+      this.convToKST(data.apply_date),
+      data.requestd ? 'O' : '',
+      data.issued ? 'O' : '',
+      data.picked ? 'O' : '',
+      data.origin_card_id,
+      data.new_card_id,
+    ];
+    try {
+      const sheet = sheets('v4');
+      const params = {
+        auth: auth,
+        spreadsheetId: this.gsSheetId,
+        range,
+        valueInputOption: option,
+        requestBody: {
+          values: [value],
+        },
+      };
+      if (data.idx) {
+        await sheet.spreadsheets.values.update(params);
+      } else {
+        await sheet.spreadsheets.values.append(params);
+      }
+    } catch (e) {
+      this.logger.error(e.message);
+    }
+  }
+}

--- a/src/reissue/repository/interface/card-reissue.repository.interface.ts
+++ b/src/reissue/repository/interface/card-reissue.repository.interface.ts
@@ -1,0 +1,17 @@
+import { CardReissue } from 'src/entities/card-reissue.entity';
+
+export interface ICardReissueRepository {
+  /**
+   * 특정 유저에 대한 카드 발급 현황을 가지고 옵니다.
+   *
+   * @param user_id 사용자 아이디에 해당하는 row 반환
+   */
+  findByUserId(user_id: number): Promise<CardReissue[]>;
+
+  /**
+   * 1개의 row를 추가 또는 업데이트합니다.
+   *
+   * @param data 하나의 row 추가 또는 업데이트
+   */
+  save(data: CardReissue): Promise<void>;
+}

--- a/src/utils/google-api.component.ts
+++ b/src/utils/google-api.component.ts
@@ -13,19 +13,8 @@ import { sheets, auth } from '@googleapis/sheets';
 @Injectable()
 export class GoogleApi {
   private logger = new Logger(GoogleApi.name);
-  private _envEmail = this.configService.get<string>('googleCardApi.email');
-  private _key = this.configService.get<string>('googleCardApi.key');
-  private _gsId = this.configService.get<string>('googleCardApi.spreadsheetId');
-  private _gsRange = this.configService.get<string>('googleCardApi.range');
-  private _scope = ['https://www.googleapis.com/auth/spreadsheets'];
   constructor(@Inject(ConfigService) private configService: ConfigService) {}
 
-  get gsId() {
-    return this._gsId;
-  }
-  get gsRange() {
-    return this._gsRange;
-  }
   async transportData(data: string): Promise<boolean> {
     this.logger.log(`call transportData (data: ${data})`);
     let result = true;
@@ -54,82 +43,5 @@ export class GoogleApi {
       result = false;
     }
     return result;
-  }
-
-  authorize(): any {
-    const googleAuth = new auth.JWT({
-      email: this._envEmail,
-      key: this._key,
-      scopes: this._scope,
-    });
-    return googleAuth;
-  }
-
-  async getAllValues(): Promise<any[][]> {
-    const auth = this.authorize();
-    let result = [];
-    try {
-      const sheet = sheets('v4');
-      const allCardReissues = await sheet.spreadsheets.values.get({
-        auth: auth,
-        spreadsheetId: this.gsId,
-        range: this.gsRange,
-      });
-      result = allCardReissues.data.values;
-    } catch (error) {
-      this.logger.error(
-        `@getAllValues) failed to read google sheet: ${error.message}`,
-      );
-      throw new ServiceUnavailableException(
-        `구글스프레드 시트 조회 실패: ${error.message}`,
-      );
-    }
-    return result;
-  }
-
-  async appendValues(data: (string | number)[]): Promise<void> {
-    const auth = this.authorize();
-    try {
-      const sheet = sheets('v4');
-      await sheet.spreadsheets.values.append({
-        auth: auth,
-        spreadsheetId: this.gsId,
-        range: this.gsRange,
-        valueInputOption: 'RAW',
-        requestBody: {
-          values: [data],
-        },
-      });
-    } catch (error) {
-      this.logger.error(
-        `@appendValues) failed to append to google sheet: ${error.message}`,
-      );
-      throw new ServiceUnavailableException(
-        `카드 재발급 신청 구글스프레드 시트에 추가 실패: ${error.message}`,
-      );
-    }
-  }
-
-  async updateValues(rowNum: number, data: string): Promise<void> {
-    const auth = this.authorize();
-    try {
-      const sheet = sheets('v4');
-      await sheet.spreadsheets.values.update({
-        auth: auth,
-        spreadsheetId: this.gsId,
-        range: this.gsRange + `!F${rowNum}`,
-        requestBody: {
-          values: [[data]],
-        },
-        valueInputOption: 'USER_ENTERED',
-      });
-    } catch (error) {
-      this.logger.error(
-        `@updateValues) failed to update google sheet: ${error.message}`,
-      );
-      throw new ServiceUnavailableException(
-        `수령완료 행 구글스프레드 시트에 업데이트 실패: ${error.message}`,
-      );
-    }
   }
 }

--- a/src/utils/google-api.component.ts
+++ b/src/utils/google-api.component.ts
@@ -2,7 +2,6 @@ import {
   Inject,
   Injectable,
   Logger,
-  ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { sheets, auth } from '@googleapis/sheets';


### PR DESCRIPTION
## 수정 및 작업 내용
- (카드 재발급 관련) 구글 시트의 셀에 대응되게 엔티티를 만들고 구글 시트에 접근하는 코드는 모두 리포지토리의 구현으로 이동시켰습니다.
- 리포지토리의 메소드는 ORM에서 제공하는 함수와 비슷하게 명명하였습니다.

## 사유
- #136
