### PR TITLE
fix: #148 월초 00시 가상로그 임시조치

### DIFF
--- a/src/tag-log-v2/tag-log-v2.service.ts
+++ b/src/tag-log-v2/tag-log-v2.service.ts
@@ -151,6 +151,18 @@ export class TagLogService {
 
     // 타임라인 배열이 빌 때까지 루프를 돌립니다.
     while (timeLines.length > 0) {
+      //todo: 임시해결 :( 로직 살펴보고 고치기
+      if (timeLines.length <= 2) {
+        this.logger.debug(taglogs[0].idx);
+        if (taglogs[0].idx === -1) {
+          resultPairs.push({
+            inTimeStamp: this.dateCalculator.toTimestamp(taglogs[0].tag_at),
+            outTimeStamp: this.dateCalculator.toTimestamp(taglogs[1].tag_at),
+            durationSecond: this.dateCalculator.toTimestamp(taglogs[1].tag_at) - this.dateCalculator.toTimestamp(taglogs[0].tag_at),
+          })
+        }
+      }
+
       if (temp === null) {
         temp = timeLines.pop();
       }
@@ -239,7 +251,7 @@ export class TagLogService {
         });
 
         // 그리고 가상 퇴장시간을 다시 배열에 넣어 가상 퇴장시간과 맞는 짝을 찾습니다.
-        timeLines.push(temp); //todo: temp? leave?
+        timeLines.push(temp);
         timeLines.push({
           tag_at: virtualLeaveTime,
           device_id: leave.device_id,


### PR DESCRIPTION
- #148

## 수정 및 작업 내용
- taglogs에서 매월 첫 날 00시 가상로그를 붙여주는데, null페어를 만드는 함수에서 idx를 확인하지 않음에도 불구하고 넣었던 로그가 무시되는 문제를 확인했습니다. 서비스 중이라 우선은 임시방편으로 해결해두었는데, 후에 추가로 작업해야해요!!

## 다음 작업
- 로직 개선
- 추가로 기기 페어 확인하는 코드가 주석이던데, 저번 이슈와 더불어 버전 나누는 과정에서 코드와 로직의 일부분이 날아간게 아닐까 생각됩니다 🤔 분명 가상로그쪽에선 문제가 없었는데...
