### PR TITLE
fix: #153 매월 마지막 날 가상로그 없애기

### DIFF
--- a/src/tag-log-v2/tag-log-v2.service.ts
+++ b/src/tag-log-v2/tag-log-v2.service.ts
@@ -56,6 +56,9 @@ export class TagLogService {
     end: Date,
   ): Promise<TagLogDto[]> {
     this.logger.debug(`@trimTagLogs)`);
+
+    const pairs = await this.pairInfoRepository.findAll();
+
     // 1. 맨 앞의 로그를 가져옴.
     const firstLog = taglogs.at(0);
     if (firstLog) {
@@ -65,7 +68,7 @@ export class TagLogService {
         firstLog.tag_at,
       );
       // NOTE: tag log에 기록된 첫번째 로그가 퇴실인 경우 현재는 짝을 맞추지 않음.
-      if (beforeFirstLog !== null) {
+      if (beforeFirstLog !== null && this.isOutDevice(pairs, firstLog.device_id)) {
         const virtualEnterTime = this.dateCalculator.getStartOfDate(start);
         taglogs.unshift({
           tag_at: virtualEnterTime,
@@ -84,7 +87,7 @@ export class TagLogService {
         lastLog.tag_at,
       );
       // NOTE: 현재는 카뎃의 현재 입실여부에 관계없이 짝을 맞춤.
-      if (afterLastLog !== null) {
+      if (afterLastLog !== null && this.isInDevice(pairs, lastLog.device_id)) {
         const virtualLeaveTime = this.dateCalculator.getEndOfDate(end);
         taglogs.push({
           tag_at: virtualLeaveTime,

--- a/src/tag-log-v2/tag-log-v2.service.ts
+++ b/src/tag-log-v2/tag-log-v2.service.ts
@@ -68,7 +68,7 @@ export class TagLogService {
         firstLog.tag_at,
       );
       // NOTE: tag log에 기록된 첫번째 로그가 퇴실인 경우 현재는 짝을 맞추지 않음.
-      if (beforeFirstLog !== null && this.isOutDevice(pairs, firstLog.device_id)) {
+      if (beforeFirstLog !== null && this.validateDevicePair(pairs, beforeFirstLog.device_id, firstLog.device_id)) {
         const virtualEnterTime = this.dateCalculator.getStartOfDate(start);
         taglogs.unshift({
           tag_at: virtualEnterTime,
@@ -87,7 +87,7 @@ export class TagLogService {
         lastLog.tag_at,
       );
       // NOTE: 현재는 카뎃의 현재 입실여부에 관계없이 짝을 맞춤.
-      if (afterLastLog !== null && this.isInDevice(pairs, lastLog.device_id)) {
+      if (afterLastLog !== null && this.validateDevicePair(pairs, lastLog.device_id, afterLastLog.device_id)) {
         const virtualLeaveTime = this.dateCalculator.getEndOfDate(end);
         taglogs.push({
           tag_at: virtualLeaveTime,
@@ -107,19 +107,19 @@ export class TagLogService {
   // * @param enterDevice
   // * @param device
   // */
-  //validateDevicePair(
-  //  deviceInfos: PairInfoDto[],
-  //  inDevice: number,
-  //  outDevice: number,
-  //): boolean {
-  //  //this.logger.debug(`@validateDevicePair) ${inDevice} - ${outDevice}`);
-  //  // TODO: O(N) 보다 더 적게 시간을 소요하도록 리팩터링 필요
-  //  const find = deviceInfos.find(
-  //    (device) =>
-  //      device.in_device === inDevice && device.out_device === outDevice,
-  //  );
-  //  return !!find;
-  //}
+  validateDevicePair(
+    deviceInfos: PairInfoDto[],
+    inDevice: number,
+    outDevice: number,
+  ): boolean {
+    //this.logger.debug(`@validateDevicePair) ${inDevice} - ${outDevice}`);
+    // TODO: O(N) 보다 더 적게 시간을 소요하도록 리팩터링 필요
+    const find = deviceInfos.find(
+      (device) =>
+        device.in_device === inDevice && device.out_device === outDevice,
+    );
+    return !!find;
+  }
 
   /**
    * 인자로 들어간 디바이스 번호가 입실 디바이스인지 확인합니다.


### PR DESCRIPTION
## 수정 및 작업 내용
얘기한대로 기기 페어를 확인한 후 삽입해주는 것으로 변경했습니다.
```
변경 전: if (beforeFirstLog !== null) { ... 00:00:00 추가
변경 후: if (beforeFirstLog !== null && this.validateDevicePair(pairs, beforeFirstLog.device_id, firstLog.device_id)) { ... 00:00:00 추가
```
마찬가지로 lastLog의 IN과 afterLastLog의 OUT도 추가되었습니다.

## 테스트
- [x] 기존에 있는 테스트 케이스 확인
- [x] 직접 확인
- [ ] 테스트 코드 새로 작성

## 추가
9기분들 로그도 확인했습니다.

랜덤채널에 올라온 suham님은 케이스가 조금 특이한데, 
3월달 전체 로그에서는 3월 13일 OUT로그가 첫 로그이지만, DB에서는 3월 12일 로그도 존재합니다. 😕 
<img width="619" alt="image" src="https://user-images.githubusercontent.com/74657997/226475282-68d1cf37-fe55-42e6-a808-c792d080c016.png">

trimTagLogs 에서 첫 번째 로그의 앞 로그가 null이 아니라 3월 1일 00시 로그가 삽입되었고,
13일날 OUT으로 태깅이 시작되어 1일~13일간 전부 출석으로 표시되었네요...
trim에서 조건을 더 줘야하는건지 왜 3월 첫 로그가 13일인건지 모르겠어서 적어둡니다.

## 관련 이슈
- close #153 