### PR TITLE
s**** 님 버그 수정 (#165)

### DIFF
--- a/src/redirect/redirect.module.ts
+++ b/src/redirect/redirect.module.ts
@@ -1,6 +1,6 @@
-import { Module } from "@nestjs/common";
-import { RedirectController } from "./redirect.controller";
-import { RedirectService } from "./redirect.service";
+import { Module } from '@nestjs/common';
+import { RedirectController } from './redirect.controller';
+import { RedirectService } from './redirect.service';
 
 @Module({
   controllers: [RedirectController],

--- a/src/reissue/reissue.service.ts
+++ b/src/reissue/reissue.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   Logger,
   NotFoundException,
-  ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UserSessionDto } from '../auth/dto/user.session.dto';
@@ -109,7 +108,7 @@ export class ReissueService {
       origin_card_id: initialCardNo,
       new_card_id: '',
     };
-   await this.cardReissueRepository.save(data);
+    await this.cardReissueRepository.save(data);
     try {
       const jandiData = {
         request: 'request',

--- a/src/tag-log-v1/repository/interface/tag-log-repository.interface.ts
+++ b/src/tag-log-v1/repository/interface/tag-log-repository.interface.ts
@@ -40,18 +40,18 @@ export interface ITagLogRepository {
   findFirstTagLog(cards: CardDto[]): Promise<TagLogDto | null>;
 
   /**
-   * 특정 출입태그 시간의 바로 이전 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
+   * 특정 카드로 태그한 특정 출입태그 시간의 바로 이전 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
    *
    * @param date 출입태그 시간
-   * @param cardIDs 카드 ID 배열
+   * @param cardID 카드 ID
    */
-  findPrevTagLog(cardIDs: string[], date: Date): Promise<TagLogDto | null>;
+  findPrevTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null>;
 
   /**
-   * 특정 출입태그 시간의 바로 다음 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
+   * 특정 카드로 태그한 특정 출입태그 시간의 바로 다음 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
    *
    * @param date 출입태그 시간
-   * @param cardIDs 카드 ID 배열
+   * @param cardID 카드 ID
    */
-  findNextTagLog(cardIDs: string[], date: Date): Promise<TagLogDto | null>;
+  findNextTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null>;
 }

--- a/src/tag-log-v1/repository/mysql/tag-log.repository.ts
+++ b/src/tag-log-v1/repository/mysql/tag-log.repository.ts
@@ -84,35 +84,35 @@ export class TagLogRepository implements ITagLogRepository {
     return result;
   }
 
-  async findPrevTagLog(
-    cardIDs: string[],
-    date: Date,
-  ): Promise<TagLogDto | null> {
+  async findPrevTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null> {
     const result = await this.tagLogRepository.findOne({
       where: {
-        card_id: In(cardIDs),
+        card_id: cardID.card_id,
         tag_at: LessThan(date),
       },
       order: {
         idx: 'DESC',
       },
     });
+    if (result && cardID.begin.getTime() > result.tag_at.getTime()) {
+      return null;
+    }
     return result;
   }
 
-  async findNextTagLog(
-    cardIDs: string[],
-    date: Date,
-  ): Promise<TagLogDto | null> {
+  async findNextTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null> {
     const result = await this.tagLogRepository.findOne({
       where: {
-        card_id: In(cardIDs),
+        card_id: cardID.card_id,
         tag_at: MoreThan(date),
       },
       order: {
         idx: 'ASC',
       },
     });
+    if (result && cardID.end.getTime() < result.tag_at.getTime()) {
+      return null;
+    }
     return result;
   }
 }

--- a/src/tag-log-v1/tag-log.service.ts
+++ b/src/tag-log-v1/tag-log.service.ts
@@ -8,6 +8,7 @@ import { PairInfoDto } from './dto/pair-info.dto';
 import { InOutLogType } from './dto/subType/InOutLog.type';
 import { ITagLogRepository } from './repository/interface/tag-log-repository.interface';
 import { IPairInfoRepository } from './repository/interface/pair-info-repository.interface';
+import { CardDto } from 'src/user/dto/card.dto';
 
 @Injectable()
 export class TagLogService {
@@ -27,13 +28,15 @@ export class TagLogService {
    * 삽입하는 로그는 짝 여부에 관계없이 전후 원소를 삽입합니다.
    * 짝 일치 여부 판단은 다른 로직에서 진행합니다.
    * version 2: 카드의 짝을 맞추도록 수정하였습니다.
+   * version 3: 이전/이후 로그를 가져올 때, 카드의 유효 기간도 고려하도록 변경하였습니다.
    *
    * @param taglogs TagLogDto[]
    * @return TagLogDto[]
-   * @version 2
+   * @version 3
    */
   async trimTagLogs(
     taglogs: TagLogDto[],
+    cards: CardDto[],
     start: Date,
     end: Date,
   ): Promise<TagLogDto[]> {
@@ -43,7 +46,7 @@ export class TagLogService {
     if (firstLog) {
       // 2. 맨 앞의 로그 이전의 로그를 가져옴.
       const beforeFirstLog = await this.tagLogRepository.findPrevTagLog(
-        [firstLog.card_id],
+        cards.find((v) => v.card_id === firstLog.card_id),
         firstLog.tag_at,
       );
       // NOTE: tag log에 기록된 첫번째 로그가 퇴실인 경우 현재는 짝을 맞추지 않음.
@@ -62,7 +65,7 @@ export class TagLogService {
     if (lastLog) {
       // 6. 맨 뒤의 로그 이후의 로그를 가져옴.
       const afterLastLog = await this.tagLogRepository.findNextTagLog(
-        [lastLog.card_id],
+        cards.find((v) => v.card_id === lastLog.card_id),
         lastLog.tag_at,
       );
       // NOTE: 현재는 카뎃의 현재 입실여부에 관계없이 짝을 맞춤.
@@ -235,6 +238,7 @@ export class TagLogService {
 
     const trimmedTagLogs = await this.trimTagLogs(
       filteredTagLogs,
+      cards,
       tagStart,
       tagEnd,
     );
@@ -281,6 +285,7 @@ export class TagLogService {
 
     const trimmedTagLogs = await this.trimTagLogs(
       filteredTagLogs,
+      cards,
       tagStart,
       tagEnd,
     );

--- a/src/tag-log-v2/dto/user-accumulation.type.ts
+++ b/src/tag-log-v2/dto/user-accumulation.type.ts
@@ -18,7 +18,7 @@ export class UserAccumulationType {
     example: [1234, 5678, 9012, 3456, 7890, 1234],
   })
   sixWeekAccumulationTime: number[];
-  
+
   @ApiProperty({
     description: '최근 6개월간의 누적시간',
     example: [12345, 67890, 12345, 67890, 12345, 67890],

--- a/src/tag-log-v2/repository/interface/tag-log-repository.interface.ts
+++ b/src/tag-log-v2/repository/interface/tag-log-repository.interface.ts
@@ -40,18 +40,18 @@ export interface ITagLogRepository {
   findFirstTagLog(cards: CardDto[]): Promise<TagLogDto | null>;
 
   /**
-   * 특정 출입태그 시간의 바로 이전 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
+   * 특정 카드로 태그한 특정 출입태그 시간의 바로 이전 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
    *
    * @param date 출입태그 시간
-   * @param cardIDs 카드 ID 배열
+   * @param cardID 카드 ID
    */
-  findPrevTagLog(cardIDs: string[], date: Date): Promise<TagLogDto | null>;
+  findPrevTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null>;
 
   /**
-   * 특정 출입태그 시간의 바로 다음 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
+   * 특정 카드로 태그한 특정 출입태그 시간의 바로 다음 태그 로그를 가져옵니다. 없다면 null을 반환합니다.
    *
    * @param date 출입태그 시간
-   * @param cardIDs 카드 ID 배열
+   * @param cardID 카드 ID
    */
-  findNextTagLog(cardIDs: string[], date: Date): Promise<TagLogDto | null>;
+  findNextTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null>;
 }

--- a/src/tag-log-v2/repository/mysql/tag-log.repository.ts
+++ b/src/tag-log-v2/repository/mysql/tag-log.repository.ts
@@ -84,35 +84,35 @@ export class TagLogRepository implements ITagLogRepository {
     return result;
   }
 
-  async findPrevTagLog(
-    cardIDs: string[],
-    date: Date,
-  ): Promise<TagLogDto | null> {
+  async findPrevTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null> {
     const result = await this.tagLogRepository.findOne({
       where: {
-        card_id: In(cardIDs),
+        card_id: cardID.card_id,
         tag_at: LessThan(date),
       },
       order: {
         idx: 'DESC',
       },
     });
+    if (result && cardID.begin.getTime() > result.tag_at.getTime()) {
+      return null;
+    }
     return result;
   }
 
-  async findNextTagLog(
-    cardIDs: string[],
-    date: Date,
-  ): Promise<TagLogDto | null> {
+  async findNextTagLog(cardID: CardDto, date: Date): Promise<TagLogDto | null> {
     const result = await this.tagLogRepository.findOne({
       where: {
-        card_id: In(cardIDs),
+        card_id: cardID.card_id,
         tag_at: MoreThan(date),
       },
       order: {
         idx: 'ASC',
       },
     });
+    if (result && cardID.end.getTime() < result.tag_at.getTime()) {
+      return null;
+    }
     return result;
   }
 }

--- a/src/tag-log-v2/tag-log-v2.controller.ts
+++ b/src/tag-log-v2/tag-log-v2.controller.ts
@@ -85,11 +85,16 @@ export class TagLogController {
     @Query('month', ParseIntPipe) month: number,
     @Query('day', ParseIntPipe) day: number,
   ): Promise<UserInOutLogsType> {
-    this.logger.debug(`@getAllTagPerDay) ${year}-${month}-${day} by ${user.login}`);
+    this.logger.debug(
+      `@getAllTagPerDay) ${year}-${month}-${day} by ${user.login}`,
+    );
 
     const date = new Date(`${year}-${month}-${day}`);
 
-    const results = await this.tagLogService.getAllTagPerDay(user.user_id, date);
+    const results = await this.tagLogService.getAllTagPerDay(
+      user.user_id,
+      date,
+    );
     return {
       login: user.login,
       profileImage: user.image_url,
@@ -138,7 +143,10 @@ export class TagLogController {
 
     const date = new Date(`${year}-${month}`);
 
-    const results = await this.tagLogService.getAllTagPerMonth(user.user_id, date);
+    const results = await this.tagLogService.getAllTagPerMonth(
+      user.user_id,
+      date,
+    );
     return {
       login: user.login,
       profileImage: user.image_url,
@@ -212,7 +220,10 @@ export class TagLogController {
   ): Promise<UserAccumulationType> {
     this.logger.debug(`@getAccumulationTimes) by ${user.login}`);
     const date = new Date();
-    const resultDay = await this.tagLogService.getAllTagPerDay(user.user_id, date);
+    const resultDay = await this.tagLogService.getAllTagPerDay(
+      user.user_id,
+      date,
+    );
     const resultMonth = await this.tagLogService.getAllTagPerMonth(
       user.user_id,
       date,
@@ -227,8 +238,12 @@ export class TagLogController {
       0,
     );
 
-    const resultSixWeekArray = await this.tagLogService.getTimeSixWeek(user.user_id);
-    const resultSixMonthArray = await this.tagLogService.getTimeSixMonth(user.user_id);
+    const resultSixWeekArray = await this.tagLogService.getTimeSixWeek(
+      user.user_id,
+    );
+    const resultSixMonthArray = await this.tagLogService.getTimeSixMonth(
+      user.user_id,
+    );
 
     const result: UserAccumulationType = {
       todayAccumulationTime: resultDaySum,

--- a/src/tag-log-v2/tag-log-v2.service.ts
+++ b/src/tag-log-v2/tag-log-v2.service.ts
@@ -8,6 +8,7 @@ import { PairInfoDto } from './dto/pair-info.dto';
 import { InOutLogType } from './dto/subType/InOutLog.type';
 import { ITagLogRepository } from './repository/interface/tag-log-repository.interface';
 import { IPairInfoRepository } from './repository/interface/pair-info-repository.interface';
+import { CardDto } from 'src/user/dto/card.dto';
 
 @Injectable()
 export class TagLogService {
@@ -45,30 +46,39 @@ export class TagLogService {
    * 삽입하는 로그는 짝 여부에 관계없이 전후 원소를 삽입합니다.
    * 짝 일치 여부 판단은 다른 로직에서 진행합니다.
    * version 2: 카드의 짝을 맞추도록 수정하였습니다.
+   * version 3: 카드의 짝을 엄밀하게 맞추도록 수정하였습니다.
+   * version 4: 이전/이후 로그를 가져올 때, 카드의 유효 기간도 고려하도록 변경하였습니다.
    *
    * @param taglogs TagLogDto[]
    * @return TagLogDto[]
-   * @version 2
+   * @version 4
    */
   async trimTagLogs(
     taglogs: TagLogDto[],
+    cards: CardDto[],
     start: Date,
     end: Date,
+    pairs: PairInfoDto[],
   ): Promise<TagLogDto[]> {
     this.logger.debug(`@trimTagLogs)`);
-
-    const pairs = await this.pairInfoRepository.findAll();
 
     // 1. 맨 앞의 로그를 가져옴.
     const firstLog = taglogs.at(0);
     if (firstLog) {
       // 2. 맨 앞의 로그 이전의 로그를 가져옴.
       const beforeFirstLog = await this.tagLogRepository.findPrevTagLog(
-        [firstLog.card_id],
+        cards.find((v) => v.card_id === firstLog.card_id),
         firstLog.tag_at,
       );
       // NOTE: tag log에 기록된 첫번째 로그가 퇴실인 경우 현재는 짝을 맞추지 않음.
-      if (beforeFirstLog !== null && this.validateDevicePair(pairs, beforeFirstLog.device_id, firstLog.device_id)) {
+      if (
+        beforeFirstLog !== null &&
+        this.validateDevicePair(
+          pairs,
+          beforeFirstLog.device_id,
+          firstLog.device_id,
+        )
+      ) {
         const virtualEnterTime = this.dateCalculator.getStartOfDate(start);
         taglogs.unshift({
           tag_at: virtualEnterTime,
@@ -83,11 +93,18 @@ export class TagLogService {
     if (lastLog) {
       // 6. 맨 뒤의 로그 이후의 로그를 가져옴.
       const afterLastLog = await this.tagLogRepository.findNextTagLog(
-        [lastLog.card_id],
+        cards.find((v) => v.card_id === lastLog.card_id),
         lastLog.tag_at,
       );
       // NOTE: 현재는 카뎃의 현재 입실여부에 관계없이 짝을 맞춤.
-      if (afterLastLog !== null && this.validateDevicePair(pairs, lastLog.device_id, afterLastLog.device_id)) {
+      if (
+        afterLastLog !== null &&
+        this.validateDevicePair(
+          pairs,
+          lastLog.device_id,
+          afterLastLog.device_id,
+        )
+      ) {
         const virtualLeaveTime = this.dateCalculator.getEndOfDate(end);
         taglogs.push({
           tag_at: virtualLeaveTime,
@@ -316,8 +333,10 @@ export class TagLogService {
 
     const trimmedTagLogs = await this.trimTagLogs(
       filteredTagLogs,
+      cards,
       tagStart,
       tagEnd,
+      devicePairs,
     );
 
     return trimmedTagLogs;

--- a/src/utils/date-calculator.component.ts
+++ b/src/utils/date-calculator.component.ts
@@ -56,7 +56,11 @@ export class DateCalculator {
   getStartOfWeek(date: Date): Date {
     const dayOfWeek = date.getDay() - 1;
     const diff = dayOfWeek === -1 ? 6 : dayOfWeek;
-    const rtn = new Date(date.getFullYear(), date.getMonth(), date.getDate() - diff);
+    const rtn = new Date(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate() - diff,
+    );
     return rtn;
   }
 
@@ -125,11 +129,11 @@ export class DateCalculator {
 
   /**
    * 주어진 년, 월에 대해 일의 개수를 구합니다.
-  *
-  * @param year 년
-  * @param month 월
-  * @return days 해당 달의 일의 개수
-  */
+   *
+   * @param year 년
+   * @param month 월
+   * @return days 해당 달의 일의 개수
+   */
   getDaysInMonth(year: number, month: number): number {
     this.logger.debug(`@getDaysInMonth) ${year}, ${month}`);
     const date = new Date(year, month, 0);
@@ -138,17 +142,19 @@ export class DateCalculator {
 
   /**
    * 주어진 년도와 주차에 대해 날짜 범위를 구합니다.
-   * 
+   *
    * @param year 년
    * @param week 주차
-   * @returns 
-  */
+   * @returns
+   */
   getDateOfWeek(year: number, week: number): Date {
     const januaryFirst = new Date(year, 0, 1);
     const dayOfWeek = januaryFirst.getDay();
     const daysToAdd = 7 - dayOfWeek;
     const secondSundayOfYear = new Date(year, 0, daysToAdd + 1);
-    const rtn = new Date(secondSundayOfYear.getTime() + (week - 1) * 7 * 24 * 60 * 60 * 1000);
+    const rtn = new Date(
+      secondSundayOfYear.getTime() + (week - 1) * 7 * 24 * 60 * 60 * 1000,
+    );
     return rtn;
   }
 }

--- a/src/utils/google-api.component.ts
+++ b/src/utils/google-api.component.ts
@@ -1,8 +1,4 @@
-import {
-  Inject,
-  Injectable,
-  Logger,
-} from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { sheets, auth } from '@googleapis/sheets';
 


### PR DESCRIPTION
## 수정 및 작업 내용
- 가상 로그를 삽입하기 위한 전/후 로그에 접근할 때, 카드의 유효기간도 반영하도록 수정하였습니다.
  - 지원금 산정과 직접적으로 연관이 있기 때문에, 현재 운영진 분들이 사용하는 v1에도 반영하였습니다.
- 추가로, #164 작업에 대해 리팩터링도 했습니다. (IN/OUT 로그를 기존에 가져온 데이터를 사용하도록)
- `npm run lint` 로 린트 수정 하였습니다. PR 올리기 전, `npm run lint` 실행하여 린트 체크 해야 할 거 같습니다.

## 사유
- #165
