### PR TITLE
#143 trim 로직 개선

### DIFF
--- a/src/tag-log-v2/dto/device-info.dto.ts
+++ b/src/tag-log-v2/dto/device-info.dto.ts
@@ -1,0 +1,8 @@
+import Cluster from 'src/enums/cluster.enum';
+import InOut from 'src/enums/inout.enum';
+
+export class DeviceInfoDto {
+  device_id: number;
+  campus: Cluster;
+  io_type: InOut;
+}

--- a/src/tag-log-v2/repository/interface/device-info-repository.interface.ts
+++ b/src/tag-log-v2/repository/interface/device-info-repository.interface.ts
@@ -1,0 +1,8 @@
+import { DeviceInfoDto } from 'src/tag-log-v2/dto/device-info.dto';
+
+export interface IDeviceInfoRepository {
+  /**
+   * 모든 등록된 카드태깅 디바이스 정보를 가져옵니다.
+   */
+  findAll(): Promise<DeviceInfoDto[]>;
+}

--- a/src/tag-log-v2/repository/mysql/device-info.repository.ts
+++ b/src/tag-log-v2/repository/mysql/device-info.repository.ts
@@ -1,0 +1,16 @@
+import { DeviceInfoDto } from 'src/tag-log-v2/dto/device-info.dto';
+import { IDeviceInfoRepository } from '../interface/device-info-repository.interface';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DeviceInfo } from 'src/entities/device-info.entity';
+
+export class DeviceInfoRepository implements IDeviceInfoRepository {
+  constructor(
+    @InjectRepository(DeviceInfo)
+    private deviceInfoRepository: Repository<DeviceInfo>,
+  ) {}
+
+  async findAll(): Promise<DeviceInfoDto[]> {
+    return await this.deviceInfoRepository.find();
+  }
+}

--- a/src/tag-log-v2/tag-log-v2.module.ts
+++ b/src/tag-log-v2/tag-log-v2.module.ts
@@ -10,6 +10,8 @@ import { TagLogRepository } from './repository/mysql/tag-log.repository';
 import { TagLogController } from './tag-log-v2.controller';
 import { TagLogService } from './tag-log-v2.service';
 import { StatisticsModule } from 'src/statistics/statictics.module';
+import { DeviceInfo } from 'src/entities/device-info.entity';
+import { DeviceInfoRepository } from './repository/mysql/device-info.repository';
 
 const tagLogRepo = {
   provide: 'ITagLogRepository',
@@ -21,16 +23,21 @@ const pairInfoRepo = {
   useClass: PairInfoRepository,
 };
 
+const deviceInfoRepo = {
+  provide: 'IDeviceInfoRepository',
+  useClass: DeviceInfoRepository,
+};
+
 @Module({
   imports: [
     AuthModule,
-    TypeOrmModule.forFeature([TagLog, PairInfo]),
+    TypeOrmModule.forFeature([TagLog, PairInfo, DeviceInfo]),
     UtilsModule,
     UserModule,
     StatisticsModule,
   ],
   exports: [TypeOrmModule],
   controllers: [TagLogController],
-  providers: [tagLogRepo, pairInfoRepo, TagLogService],
+  providers: [tagLogRepo, pairInfoRepo, deviceInfoRepo, TagLogService],
 })
 export class TagLogModule2 {}

--- a/src/tag-log-v2/tag-log-v2.service.spec.ts
+++ b/src/tag-log-v2/tag-log-v2.service.spec.ts
@@ -18,6 +18,10 @@ const mocks = [
     provide: 'IPairInfoRepository',
     useClass: jest.fn(),
   },
+  {
+    provide: 'IDeviceInfoRepository',
+    useClass: jest.fn(),
+  },
 ];
 
 describe('Tag Log (v2) unit 테스트', () => {


### PR DESCRIPTION
## 수정 및 작업 내용
- trim 로직에서 무조건 이전, 이후 태그로그에 접근해서 성능 하락 이슈가 있었습니다.
- 필요한 경우에만 이전,이후 로그에 접근하게 하여 성능을 향상시켰습니다.

## 사유
- #143
