### PR TITLE
✨ feat: 어디있니 추가 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "24hane",
-  "version": "4.2.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "24hane",
-      "version": "4.2.1",
+      "version": "5.1.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@googleapis/sheets": "^5.0.5",
@@ -1840,15 +1840,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.2.10",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.2.10.tgz",
-      "integrity": "sha512-U4KDgtMjH8TqEvt0RzC/POP8ABvL9bYoCScvlGtFSKgVGaMLBKkZ4+jHtbQx6qItYSlBBRUuz/dveMZCObfrkQ==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.3.10.tgz",
+      "integrity": "sha512-wK2ow3CZI2KFqWeEpPmoR300OB6BcBLxARV1EiClJLCj4S1mZsoCmS0YWgpk3j1j6mo0SI8vNLi/cC2iZPEPQA==",
       "dependencies": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
-        "express": "4.18.2",
+        "express": "4.19.2",
         "multer": "1.4.4-lts.1",
-        "tslib": "2.6.2"
+        "tslib": "2.6.3"
       },
       "funding": {
         "type": "opencollective",
@@ -1858,6 +1858,11 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0"
       }
+    },
+    "node_modules/@nestjs/platform-express/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/@nestjs/schematics": {
       "version": "10.0.3",
@@ -3257,12 +3262,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4723,16 +4728,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -4763,33 +4768,10 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4811,20 +4793,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4945,9 +4913,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5058,9 +5026,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -7159,9 +7127,9 @@
       "dev": true
     },
     "node_modules/mysql2": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.6.5.tgz",
-      "integrity": "sha512-pS/KqIb0xlXmtmqEuTvBXTmLoQ5LmAz5NW/r8UyQ1ldvnprNEj3P9GbmuQQ2J0A4LO+ynotGi6TbscPa8OUb+w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "24hane",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "24Hane Backend Server",
   "author": "joohongpark, niamu01, enaenen",
   "private": true,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { IAuthRepository } from './repository/auth.repository.interface';
 import { UserSessionDto } from 'src/auth/dto/user.session.dto';
+import { IAuthRepository } from './repository/auth.repository.interface';
 
 @Injectable()
 export class AuthService {

--- a/src/auth/guard/jwt-sign.guard.ts
+++ b/src/auth/guard/jwt-sign.guard.ts
@@ -1,12 +1,12 @@
-import { Request, Response } from 'express';
 import {
   CanActivate,
   ExecutionContext,
   Injectable,
   Logger,
 } from '@nestjs/common';
-import { Observable } from 'rxjs';
 import { JwtService } from '@nestjs/jwt';
+import { Request, Response } from 'express';
+import { Observable } from 'rxjs';
 import { UserSessionDto } from 'src/auth/dto/user.session.dto';
 
 /**

--- a/src/auth/srategy/auth.admin.strategy.ts
+++ b/src/auth/srategy/auth.admin.strategy.ts
@@ -1,7 +1,7 @@
-import { ExtractJwt, Strategy } from 'passport-jwt';
-import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 import { UserSessionDto } from '../dto/user.session.dto';
 
 /**

--- a/src/auth/srategy/auth.external.strategy.ts
+++ b/src/auth/srategy/auth.external.strategy.ts
@@ -1,7 +1,7 @@
-import { ExtractJwt, Strategy } from 'passport-jwt';
-import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 
 /**
  * 외부 API용 passport-jwt Strategy

--- a/src/auth/srategy/auth.strategy.ts
+++ b/src/auth/srategy/auth.strategy.ts
@@ -1,7 +1,7 @@
-import { ExtractJwt, Strategy } from 'passport-jwt';
-import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 import { UserSessionDto } from '../dto/user.session.dto';
 
 /**

--- a/src/entities/alive.entity.ts
+++ b/src/entities/alive.entity.ts
@@ -1,5 +1,5 @@
 import Cluster from 'src/enums/cluster.enum';
-import { Entity, Column, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 // deprecated
 @Entity()

--- a/src/entities/card-issuance.entity.ts
+++ b/src/entities/card-issuance.entity.ts
@@ -1,6 +1,6 @@
 import {
-  Entity,
   Column,
+  Entity,
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,

--- a/src/entities/device-info.entity.ts
+++ b/src/entities/device-info.entity.ts
@@ -1,6 +1,6 @@
 import Cluster from 'src/enums/cluster.enum';
 import InOut from 'src/enums/inout.enum';
-import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { Column, Entity, PrimaryColumn } from 'typeorm';
 
 @Entity('DEVICE_INFO')
 export class DeviceInfo {

--- a/src/entities/inout.entity.ts
+++ b/src/entities/inout.entity.ts
@@ -1,6 +1,6 @@
 import Cluster from 'src/enums/cluster.enum';
 import InOut from 'src/enums/inout.enum';
-import { Entity, Column, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 // deprecated
 @Entity()

--- a/src/entities/tag-log.entity.ts
+++ b/src/entities/tag-log.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity('TAG_LOG')
 export class TagLog {

--- a/src/entities/user-info.entity.ts
+++ b/src/entities/user-info.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany, PrimaryColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryColumn } from 'typeorm';
 import { CardIssuance } from './card-issuance.entity';
 
 @Entity('USER_INFO')

--- a/src/external/where42/dto/where42.response.dto.ts
+++ b/src/external/where42/dto/where42.response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import Cluster from 'src/enums/cluster.enum';
 import InOut from 'src/enums/inout.enum';
 
 export class Where42ResponseDto {
@@ -9,9 +10,22 @@ export class Where42ResponseDto {
   login: string;
 
   @ApiProperty({
-    description: '클러스터 체류 여부, bocal은 null',
+    description: '클러스터 체류 여부',
     enum: InOut,
     example: InOut.OUT,
   })
-  inoutState: InOut | null;
+  inoutState: InOut;
+
+  @ApiProperty({
+    description: '체류중인 클러스터',
+    enum: Cluster,
+    example: Cluster.GAEPO,
+  })
+  cluster: Cluster;
+
+  @ApiProperty({
+    description: '마지막으로 태깅한 시간',
+    type: Date,
+  })
+  tag_at: Date;
 }

--- a/src/external/where42/dto/where42.response.dto.ts
+++ b/src/external/where42/dto/where42.response.dto.ts
@@ -10,22 +10,9 @@ export class Where42ResponseDto {
   login: string;
 
   @ApiProperty({
-    description: '클러스터 체류 여부',
+    description: '클러스터 체류 여부, bocal은 null',
     enum: InOut,
     example: InOut.OUT,
   })
-  inoutState: InOut;
-
-  @ApiProperty({
-    description: '체류중인 클러스터',
-    enum: Cluster,
-    example: Cluster.GAEPO,
-  })
-  cluster: Cluster;
-
-  @ApiProperty({
-    description: '마지막으로 태깅한 시간',
-    type: Date,
-  })
-  tag_at: Date;
+  inoutState: InOut | null;
 }

--- a/src/external/where42/dto/where42.response.dto.ts
+++ b/src/external/where42/dto/where42.response.dto.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import Cluster from 'src/enums/cluster.enum';
 import InOut from 'src/enums/inout.enum';
 
 export class Where42ResponseDto {

--- a/src/external/where42/where42.controller.ts
+++ b/src/external/where42/where42.controller.ts
@@ -64,10 +64,4 @@ export class Where42Controller {
     this.logger.debug(`@where42All) where42All`);
     return this.where42Service.where42All(logins);
   }
-
-  @Post('where42All2')
-  async where42All2(@Body() logins: string[]): Promise<Where42ResponseDto[]> {
-    this.logger.debug(`@where42All) where42All`);
-    return this.where42Service.where42All2(logins);
-  }
 }

--- a/src/external/where42/where42.controller.ts
+++ b/src/external/where42/where42.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Logger, Param, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -49,5 +57,11 @@ export class Where42Controller {
   async where42(@Param('login') login: string): Promise<Where42ResponseDto> {
     this.logger.debug(`@islogin) where42: ${login}`);
     return this.where42Service.where42(login);
+  }
+
+  @Post('where42All')
+  async where42All(@Body() logins: string[]): Promise<Where42ResponseDto[]> {
+    this.logger.debug(`@where42All) where42All`);
+    return this.where42Service.where42All(logins);
   }
 }

--- a/src/external/where42/where42.controller.ts
+++ b/src/external/where42/where42.controller.ts
@@ -64,4 +64,10 @@ export class Where42Controller {
     this.logger.debug(`@where42All) where42All`);
     return this.where42Service.where42All(logins);
   }
+
+  @Post('where42All2')
+  async where42All2(@Body() logins: string[]): Promise<Where42ResponseDto[]> {
+    this.logger.debug(`@where42All) where42All`);
+    return this.where42Service.where42All2(logins);
+  }
 }

--- a/src/external/where42/where42.service.ts
+++ b/src/external/where42/where42.service.ts
@@ -1,9 +1,11 @@
 import {
   BadRequestException,
+  Body,
   ForbiddenException,
   Inject,
   Injectable,
   Logger,
+  Post,
 } from '@nestjs/common';
 import { ITagLogRepository } from 'src/tag-log/repository/interface/tag-log-repository.interface';
 import { UserService } from 'src/user/user.service';
@@ -51,8 +53,23 @@ export class Where42Service {
     return {
       login,
       inoutState: device.inoutState,
-      cluster: device.cluster,
-      tag_at: last.tag_at,
     };
+  }
+
+  @Post('where42All')
+  async where42All(@Body() logins: string[]): Promise<Where42ResponseDto[]> {
+    const res = [];
+    for (const login of logins) {
+      try {
+        res.push(await this.where42(login));
+      } catch (e) {
+        this.logger.error('정상적인 조회가 아님');
+        res.push({
+          login,
+          inoutState: null,
+        });
+      }
+    }
+    return res;
   }
 }

--- a/src/external/where42/where42.service.ts
+++ b/src/external/where42/where42.service.ts
@@ -59,23 +59,6 @@ export class Where42Service {
 
   @Post('where42All')
   async where42All(@Body() logins: string[]): Promise<Where42ResponseDto[]> {
-    const res = [];
-    for (const login of logins) {
-      try {
-        res.push(await this.where42(login));
-      } catch (e) {
-        this.logger.error('정상적인 조회가 아님');
-        res.push({
-          login,
-          inoutState: null,
-        });
-      }
-    }
-    return res;
-  }
-
-  @Post('where42All2')
-  async where42All2(@Body() logins: string[]): Promise<Where42ResponseDto[]> {
     const res: Where42ResponseDto[] = [];
 
     const users = await this.userService.findUsersByLogins(logins);

--- a/src/middleware/middleware.d.ts
+++ b/src/middleware/middleware.d.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 export type Middleware = (
   req: Request,

--- a/src/reissue/reissue.module.ts
+++ b/src/reissue/reissue.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ReissueService } from './reissue.service';
-import { ReissueController } from './reissue.controller';
-import { UserCardRepository } from './repository/mysql/user-card-no.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserInfo } from 'src/entities/user-info.entity';
+import { ReissueController } from './reissue.controller';
+import { ReissueService } from './reissue.service';
 import { CardReissueRepository } from './repository/googleApi/card-reissue.repository';
+import { UserCardRepository } from './repository/mysql/user-card-no.repository';
 
 const userCardRepo = {
   provide: 'IUserCardRepository',

--- a/src/reissue/reissue.service.ts
+++ b/src/reissue/reissue.service.ts
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import {
   HttpException,
   Inject,
@@ -7,14 +6,15 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { UserSessionDto } from '../auth/dto/user.session.dto';
-import { IUserCardRepository } from './repository/interface/user-card-no.repository.interface';
-import { StateDto } from './dto/state.dto';
-import { RequestDto } from './dto/request.dto';
-import { FinishedDto } from './dto/finished.dto';
-import ReissueState from 'src/enums/reissue-state.enum';
-import { ICardReissueRepository } from './repository/interface/card-reissue.repository.interface';
+import axios from 'axios';
 import { CardReissue } from 'src/entities/card-reissue.entity';
+import ReissueState from 'src/enums/reissue-state.enum';
+import { UserSessionDto } from '../auth/dto/user.session.dto';
+import { FinishedDto } from './dto/finished.dto';
+import { RequestDto } from './dto/request.dto';
+import { StateDto } from './dto/state.dto';
+import { ICardReissueRepository } from './repository/interface/card-reissue.repository.interface';
+import { IUserCardRepository } from './repository/interface/user-card-no.repository.interface';
 
 @Injectable()
 export class ReissueService {

--- a/src/reissue/repository/googleApi/card-reissue.repository.ts
+++ b/src/reissue/repository/googleApi/card-reissue.repository.ts
@@ -1,8 +1,8 @@
+import { auth, sheets } from '@googleapis/sheets';
 import { Inject, Logger } from '@nestjs/common';
-import { ICardReissueRepository } from '../interface/card-reissue.repository.interface';
 import { ConfigService } from '@nestjs/config';
-import { sheets, auth } from '@googleapis/sheets';
 import { CardReissue } from 'src/entities/card-reissue.entity';
+import { ICardReissueRepository } from '../interface/card-reissue.repository.interface';
 
 export class CardReissueRepository implements ICardReissueRepository {
   private logger = new Logger(CardReissueRepository.name);

--- a/src/reissue/repository/mysql/user-card-no.repository.ts
+++ b/src/reissue/repository/mysql/user-card-no.repository.ts
@@ -1,7 +1,7 @@
-import { IUserCardRepository } from '../interface/user-card-no.repository.interface';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserInfo } from 'src/entities/user-info.entity';
 import { Repository } from 'typeorm/repository/Repository';
+import { IUserCardRepository } from '../interface/user-card-no.repository.interface';
 
 export class UserCardRepository implements IUserCardRepository {
   constructor(

--- a/src/statistics/repository/mysql/statistics.repository.ts
+++ b/src/statistics/repository/mysql/statistics.repository.ts
@@ -1,8 +1,8 @@
-import { CadetPerClusterDto } from 'src/statistics/dto/cadet-per-cluster.dto';
-import { IStatisticsRepository } from '../interface/statistics.repository.interface';
-import { Repository } from 'typeorm';
-import { TagLog } from 'src/entities/tag-log.entity';
 import { InjectRepository } from '@nestjs/typeorm';
+import { TagLog } from 'src/entities/tag-log.entity';
+import { CadetPerClusterDto } from 'src/statistics/dto/cadet-per-cluster.dto';
+import { Repository } from 'typeorm';
+import { IStatisticsRepository } from '../interface/statistics.repository.interface';
 
 export class StatisticsRepository implements IStatisticsRepository {
   constructor(

--- a/src/statistics/statistics.controller.ts
+++ b/src/statistics/statistics.controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Get, Inject, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Controller, Get, Inject, Logger } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { StatisticsService } from './statistics.service';
-import { CadetPerClusterDto } from './dto/cadet-per-cluster.dto';
 import { Cache } from 'cache-manager';
+import { CadetPerClusterDto } from './dto/cadet-per-cluster.dto';
+import { StatisticsService } from './statistics.service';
 
 @ApiTags('통계 관련 API')
 @Controller({

--- a/src/statistics/statistics.module.ts
+++ b/src/statistics/statistics.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { StatisticsRepository } from './repository/mysql/statistics.repository';
-import { StatisticsService } from './statistics.service';
-import { StatisticsController } from './statistics.controller';
 import { TagLog } from 'src/entities/tag-log.entity';
+import { StatisticsRepository } from './repository/mysql/statistics.repository';
+import { StatisticsController } from './statistics.controller';
+import { StatisticsService } from './statistics.service';
 
 const statisticsRepo = {
   provide: 'IStatisticsRepository',

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -1,6 +1,6 @@
-import { Cache } from 'cache-manager';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Cache } from 'cache-manager';
 import { CadetPerClusterDto } from './dto/cadet-per-cluster.dto';
 import { IStatisticsRepository } from './repository/interface/statistics.repository.interface';
 

--- a/src/tag-log/repository/mysql/device-info.repository.ts
+++ b/src/tag-log/repository/mysql/device-info.repository.ts
@@ -1,8 +1,8 @@
-import { DeviceInfoDto } from 'src/tag-log/dto/device-info.dto';
-import { IDeviceInfoRepository } from '../interface/device-info-repository.interface';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { DeviceInfo } from 'src/entities/device-info.entity';
+import { DeviceInfoDto } from 'src/tag-log/dto/device-info.dto';
+import { Repository } from 'typeorm';
+import { IDeviceInfoRepository } from '../interface/device-info-repository.interface';
 
 export class DeviceInfoRepository implements IDeviceInfoRepository {
   constructor(

--- a/src/user/dto/id-login.dto.ts
+++ b/src/user/dto/id-login.dto.ts
@@ -12,4 +12,10 @@ export class IdLoginDto {
     example: 'joopark',
   })
   login: string;
+
+  @ApiProperty({
+    description: '관리자 여부',
+    example: true,
+  })
+  is_admin: boolean;
 }

--- a/src/user/repository/interface/user-info-repository.interface.ts
+++ b/src/user/repository/interface/user-info-repository.interface.ts
@@ -28,4 +28,12 @@ export interface IUserInfoRepository {
    * @param admin true: 관리자만, false: 카뎃만, undefined: 모두
    */
   getAllIds(admin?: boolean): Promise<IdLoginDto[]>;
+
+  /**
+   * 로그인 ID 배열에 해당하는 사용자 정보를 반환합니다.
+   *
+   * @param logins 로그인 ID 배열
+   * @returns 사용자 정보 배열
+   */
+  findUsersByLogins(logins: string[]): Promise<IdLoginDto[]>;
 }

--- a/src/user/repository/mysql/user-info.repository.ts
+++ b/src/user/repository/mysql/user-info.repository.ts
@@ -1,9 +1,9 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserInfo } from 'src/entities/user-info.entity';
-import { IUserInfoRepository } from '../interface/user-info-repository.interface';
-import { Repository, MoreThanOrEqual, LessThanOrEqual } from 'typeorm';
-import { IdLoginDto } from 'src/user/dto/id-login.dto';
 import { CardDto } from 'src/user/dto/card.dto';
+import { IdLoginDto } from 'src/user/dto/id-login.dto';
+import { In, LessThanOrEqual, MoreThanOrEqual, Repository } from 'typeorm';
+import { IUserInfoRepository } from '../interface/user-info-repository.interface';
 
 export class UserInfoRepository implements IUserInfoRepository {
   constructor(
@@ -65,6 +65,18 @@ export class UserInfoRepository implements IUserInfoRepository {
     return result.map((r) => ({
       user_id: r.user_id,
       login: r.login,
+      is_admin: r.is_admin,
+    }));
+  }
+
+  async findUsersByLogins(logins: string[]): Promise<IdLoginDto[]> {
+    const users = await this.userInfoRepository.find({
+      where: { login: In(logins) },
+    });
+    return users.map((user) => ({
+      user_id: user.user_id,
+      login: user.login,
+      is_admin: user.is_admin,
     }));
   }
 }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,8 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserInfo } from 'src/entities/user-info.entity';
 import { UserInfoRepository } from './repository/mysql/user-info.repository';
-import { UserV1Controller } from './user.v1.controller';
 import { UserService } from './user.service';
+import { UserV1Controller } from './user.v1.controller';
 
 const userInfoRepo = {
   provide: 'IUserInfoRepository',

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -51,4 +51,15 @@ export class UserService {
     this.logger.debug(`@getAllIds) ${admin}`);
     return await this.userInfoRepository.getAllIds(admin);
   }
+
+  /**
+   * 로그인 ID 배열에 해당하는 사용자 정보를 반환합니다.
+   *
+   * @param logins 로그인 ID 배열
+   * @returns 사용자 정보 배열
+   */
+  async findUsersByLogins(logins: string[]): Promise<IdLoginDto[]> {
+    this.logger.debug(`@findUsersByLogins) ${logins}`);
+    return await this.userInfoRepository.findUsersByLogins(logins);
+  }
 }

--- a/src/user/user.v1.controller.ts
+++ b/src/user/user.v1.controller.ts
@@ -11,11 +11,11 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { User } from 'src/auth/user.decorator';
 import { UserSessionDto } from 'src/auth/dto/user.session.dto';
+import { AdminAuthGuard } from 'src/auth/guard/admin-auth.guard';
+import { User } from 'src/auth/user.decorator';
 import { IdLoginDto } from './dto/id-login.dto';
 import { UserService } from './user.service';
-import { AdminAuthGuard } from 'src/auth/guard/admin-auth.guard';
 
 @ApiTags('유저 정보 관련')
 @Controller({

--- a/test/webhook.e2e-spec.ts
+++ b/test/webhook.e2e-spec.ts
@@ -1,5 +1,5 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from './../src/app.module.e2e-spec';
 
 describe('WebhookModule (e2e)', () => {


### PR DESCRIPTION
## 요청
어디있니 팀:
혹시 저희가 카뎃 이름 리스트를 파라미터로 보내면
```json
{  
  이름 : intraId
  상태 : in / out
}
```
의 DTO로 보내주실 수 있는지 생각이 들었습니다.

* 파라미터 -> body로 이야기 완료

## 추가한 API
POST 요청 속 body: 
`[ "intra-id1", "intra-id2", "intra-id3", ... ]`

응답: 
```json
[
  {
      "login": "intra-id1",
      "inoutState": "OUT"
  },
  {
      "login": "intra-id2",
      "inoutState": "IN"
  },
  {
      "login": "intra-id3",
      "inoutState": null
  },
]
```
*반환 데이터는 순서가 중요하지 않다고 하여 비동기로 처리하였습니다.
*admin유저(bocal) 혹은 없는 로그인에 대한 inoutState는 null로 반환을 요청받았습니다.
*현재는 login, inoutState뿐만 아니라 기존의 타입인 cluster, tag_at도 함께 반환합니다.

## 변경
1. 위에 언급한 예외처리를 위해 inoutState의 타입이 `InOut`에서 `InOut | null` 이 되었습니다.
2. IdLoginDto 클래스에 `is_admin` 이 추가되었습니다.

## 어디있니 팀 작업 이후 변경 예정 작업
1. Where42ResponseDto의 타입이 필요한 login과 inoutState만 남기기 (cluster, tag_at 삭제)
  a. 기존 api도 이 타입을 반환하여 함께 변경

## 여담
- import 정렬은 PR에 안 뜨게 하려고 브랜치까지 나눴었는데 그만 머지해버렸습니다. 그냥 슥 지나가 주세요...!
- inoutState랑 tag_at은 왜 같은 dto에 있는데 표기법이 왜 이렇죠...? 다음에 함수 이름 변경할 때 같이 갈아엎겠습니다.