### PR TITLE
✨ feat: refresh token 추가

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,6 +25,11 @@ GOOGLEAPI_SERVICE_ACCOUNT_PRIVATE_KEY = google API를 이용하기 위한 PEM �
 GOOGLEAPI_SHEET_ID = 변경하고자 하는 google 스프레드시트 ID
 GOOGLEAPI_SHEET_RANGE = 변경하고자 하는 google 스프레드시트의 범위
 
+GOOGLEAPI_CARD_ACCOUNT_EMAIL = google API를 이용하기 위한 이메일 (credential)
+GOOGLEAPI_CARD_ACCOUNT_PRIVATE_KEY = google API를 이용하기 위한 PEM 개인키 (credential)
+GOOGLEAPI_CARD_SHEET_ID = 변경하고자 하는 google 스프레드시트 ID
+GOOGLEAPI_CARD_SHEET_RANGE = 변경하고자 하는 google 스프레드시트의 범위
+
 JANDI_WEBHOOK_URL = 잔디 URL
 
 URI_MONEY_GUIDELINE = `/redirect/money_guidelines` 으로 리다이렉트 시킬 URI

--- a/.env.sample
+++ b/.env.sample
@@ -13,7 +13,8 @@ CLIENT_SECRET = *42인트라넷에서 발급받은 API SECRET KEY
 CLIENT_CALLBACK = *callback url, 보통 /user/login/callback/42 로 고정
 
 JWT_OR_SESSION_SECRET = *JWT 혹은 세션에 사용할 private key
-JWT_EXPIREIN = *JWT 토큰의 만료 기간 (예 : 28일 -> 28d)
+JWT_ACCESS_EXPIREIN = *JWT 엑세스 토큰의 만료 기간 (예 : 28일 -> 28d)
+JWT_REFRESH_EXPIREIN = *JWT 리프레시 토큰의 만료 기간 (예 : 28일 -> 28d)
 
 LOG_DEBUG = true일 경우 debug로그의 레벨을 debug로 false일 경우, info
 
@@ -24,9 +25,13 @@ GOOGLEAPI_SERVICE_ACCOUNT_PRIVATE_KEY = google API를 이용하기 위한 PEM �
 GOOGLEAPI_SHEET_ID = 변경하고자 하는 google 스프레드시트 ID
 GOOGLEAPI_SHEET_RANGE = 변경하고자 하는 google 스프레드시트의 범위
 
+JANDI_WEBHOOK_URL = 잔디 URL
+
 URI_MONEY_GUIDELINE = `/redirect/money_guidelines` 으로 리다이렉트 시킬 URI
 URI_QUESTION = `/redirect/question` 으로 리다이렉트 시킬 URI
 URI_USAGE = `/redirect/usage` 으로 리다이렉트 시킬 URI
 URI_FEEDBACK = `/redirect/feedback` 으로 리다이렉트 시킬 URI
 URI_TERMS = `/redirect/terms` 으로 리다이렉트 시킬 URI
 URI_REISSUANCE_GUIDELINE = `/redirect/reissuance_guidelines` 으로 리다이렉트 시킬 URI
+
+package_version = 패키지 버전

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -142,15 +142,15 @@ export class Auth42Controller {
     const jwtSecret = this.configService.getOrThrow<string>('jwt.secret');
 
     try {
-      const payload = this.jwtService.verify(refreshToken);
+      const payload = await this.jwtService.verifyAsync(refreshToken);
 
-      const newAccessToken = this.jwtService.sign(
+      const newAccessToken = await this.jwtService.signAsync(
         { login: payload.login, is_staff: payload.is_staff },
         { expiresIn: accessExpiresIn, secret: jwtSecret },
       );
 
       const accessTokenExpires = new Date(
-        this.jwtService.verify(newAccessToken)['exp'] * 1000,
+        (await this.jwtService.verifyAsync(newAccessToken)['exp']) * 1000,
       );
 
       res.cookie('accessToken', newAccessToken, {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -141,6 +141,8 @@ export class Auth42Controller {
 
     const jwtSecret = this.configService.getOrThrow<string>('jwt.secret');
 
+    this.logger.debug(`@refreshToken) refreshToken : ${refreshToken}`);
+
     try {
       const payload = await this.jwtService.verifyAsync(refreshToken);
 
@@ -149,8 +151,11 @@ export class Auth42Controller {
         { expiresIn: accessExpiresIn, secret: jwtSecret },
       );
 
+      const decodedAccessTokenForExpires =
+        await this.jwtService.verifyAsync(newAccessToken);
+
       const accessTokenExpires = new Date(
-        (await this.jwtService.verifyAsync(newAccessToken)['exp']) * 1000,
+        decodedAccessTokenForExpires['exp'] * 1000,
       );
 
       res.cookie('accessToken', newAccessToken, {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -26,9 +26,6 @@ const repo = {
     JwtModule.registerAsync({
       useFactory: async (configService: ConfigService) => ({
         secret: configService.getOrThrow<string>('jwt.secret'),
-        signOptions: {
-          expiresIn: configService.getOrThrow<string>('jwt.expiresIn'),
-        },
       }),
       inject: [ConfigService],
     }),

--- a/src/auth/guard/jwt-sign.guard.ts
+++ b/src/auth/guard/jwt-sign.guard.ts
@@ -68,11 +68,16 @@ export class JWTSignGuard implements CanActivate {
     const domain = words.join('.');
 
     // NOTE: JWT token의 만료시간을 직접 가져옴.
+    const decodedAccessTokenForExpires =
+      await this.jwtService.verifyAsync(accessToken);
+    const decodedRefreshTokenForExpires =
+      await this.jwtService.verifyAsync(refreshToken);
+
     const accessTokenexpires = new Date(
-      (await this.jwtService.verifyAsync(accessToken)['exp']) * 1000,
+      decodedAccessTokenForExpires['exp'] * 1000,
     );
     const refreshTokenexpires = new Date(
-      (await this.jwtService.verifyAsync(refreshToken)['exp']) * 1000,
+      decodedRefreshTokenForExpires['exp'] * 1000,
     );
 
     const cookieOptions = {

--- a/src/configs/configuration.ts
+++ b/src/configs/configuration.ts
@@ -15,7 +15,8 @@ export default () => ({
   },
   jwt: {
     secret: process.env.JWT_OR_SESSION_SECRET,
-    expiresIn: process.env.JWT_EXPIREIN,
+    accessExpiresIn: process.env.JWT_ACCESS_EXPIREIN,
+    refreshExpiresIn: process.env.JWT_REFRESH_EXPIREIN,
   },
   log: process.env.LOG_DEBUG === 'true' ? true : false,
   googleApi: {

--- a/src/configs/configuration.ts
+++ b/src/configs/configuration.ts
@@ -1,5 +1,4 @@
 export default () => ({
-  version: process.env.package_version,
   port: parseInt(process.env.PORT, 10),
   database: {
     host: process.env.DATABASE_HOST,
@@ -19,6 +18,9 @@ export default () => ({
     refreshExpiresIn: process.env.JWT_REFRESH_EXPIREIN,
   },
   log: process.env.LOG_DEBUG === 'true' ? true : false,
+  frontend: {
+    uri: process.env.URL_FOR_CORS,
+  },
   googleApi: {
     email: process.env.GOOGLEAPI_SERVICE_ACCOUNT_EMAIL,
     key: process.env.GOOGLEAPI_SERVICE_ACCOUNT_PRIVATE_KEY,
@@ -34,9 +36,6 @@ export default () => ({
   jandi: {
     webhook: process.env.JANDI_WEBHOOK_URL,
   },
-  frontend: {
-    uri: process.env.URL_FOR_CORS,
-  },
   redirect: {
     money_guidelines: process.env.URI_MONEY_GUIDELINE,
     question: process.env.URI_QUESTION,
@@ -45,4 +44,5 @@ export default () => ({
     terms: process.env.URI_TERMS,
     reissuance_guidelines: process.env.URI_REISSUANCE_GUIDELINE,
   },
+  version: process.env.package_version,
 });

--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -16,7 +16,7 @@ export default class TypeOrmConfigService implements TypeOrmOptionsFactory {
       password: this.configService.getOrThrow<string>('database.password'),
       database: this.configService.getOrThrow<string>('database.database'),
       entities: [`${__dirname}/../**/entities/*.entity.{js,ts}`],
-      logging: this.configService.getOrThrow<boolean>('log'),
+      logging: this.configService.get<boolean>('log'),
       charset: 'utf8mb4_general_ci',
       timezone: '+09:00',
       // cache: true, TODO: 추후에 캐시 전략 구상할 때 사용 예정

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,9 +13,11 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     logger: log_level,
   });
+
   const configService = app.get(ConfigService);
-  const cors_uri = configService.getOrThrow<string>('frontend.uri');
-  const version = configService.getOrThrow<string>('version');
+  const cors_uri = configService.get<string>('frontend.uri');
+  const version = configService.get<string>('version');
+
   // enable CORS if exists
   if (cors_uri) {
     app.enableCors({
@@ -34,9 +36,13 @@ async function bootstrap() {
     .setVersion(version)
     .addBearerAuth()
     .build();
+
   const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('docs', app, swaggerDocument);
 
-  await app.listen(parseInt(process.env.PORT, 10));
+  const port = configService.getOrThrow<number>('port');
+
+  await app.listen(port);
 }
+
 bootstrap();

--- a/src/redirect/redirect.service.ts
+++ b/src/redirect/redirect.service.ts
@@ -8,28 +8,26 @@ export class RedirectService {
   constructor(private configService: ConfigService) {}
 
   async moneyGuidelines(): Promise<string> {
-    return this.configService.getOrThrow<string>('redirect.money_guidelines');
+    return this.configService.get<string>('redirect.money_guidelines');
   }
 
   async question(): Promise<string> {
-    return this.configService.getOrThrow<string>('redirect.question');
+    return this.configService.get<string>('redirect.question');
   }
 
   async usage(): Promise<string> {
-    return this.configService.getOrThrow<string>('redirect.usage');
+    return this.configService.get<string>('redirect.usage');
   }
 
   async feedback(): Promise<string> {
-    return this.configService.getOrThrow<string>('redirect.feedback');
+    return this.configService.get<string>('redirect.feedback');
   }
 
   async terms(): Promise<string> {
-    return this.configService.getOrThrow<string>('redirect.terms');
+    return this.configService.get<string>('redirect.terms');
   }
 
   async reissuance_guidelines(): Promise<string> {
-    return this.configService.getOrThrow<string>(
-      'redirect.reissuance_guidelines',
-    );
+    return this.configService.get<string>('redirect.reissuance_guidelines');
   }
 }

--- a/src/reissue/reissue.service.ts
+++ b/src/reissue/reissue.service.ts
@@ -28,7 +28,7 @@ export class ReissueService {
   ) {}
 
   private logger = new Logger(ReissueService.name);
-  private jandiWebhook = this.configService.getOrThrow<string>('jandi.webhook');
+  private jandiWebhook = this.configService.get<string>('jandi.webhook');
 
   getTimeNowKST(): string {
     const KR_TIME_DIFF = 9 * 60 * 60 * 1000;

--- a/src/reissue/repository/googleApi/card-reissue.repository.ts
+++ b/src/reissue/repository/googleApi/card-reissue.repository.ts
@@ -15,10 +15,10 @@ export class CardReissueRepository implements ICardReissueRepository {
 
   constructor(@Inject(ConfigService) private configService: ConfigService) {
     this.gsScope = ['https://www.googleapis.com/auth/spreadsheets'];
-    this.gsKey = this.configService.getOrThrow<string>('googleCardApi.key');
-    this.gsEmail = this.configService.getOrThrow<string>('googleCardApi.email');
-    this.gsRange = this.configService.getOrThrow<string>('googleCardApi.range');
-    this.gsSheetId = this.configService.getOrThrow<string>(
+    this.gsKey = this.configService.get<string>('googleCardApi.key');
+    this.gsEmail = this.configService.get<string>('googleCardApi.email');
+    this.gsRange = this.configService.get<string>('googleCardApi.range');
+    this.gsSheetId = this.configService.get<string>(
       'googleCardApi.spreadsheetId',
     );
   }

--- a/src/utils/google-api/google-api.component.ts
+++ b/src/utils/google-api/google-api.component.ts
@@ -13,12 +13,10 @@ export class GoogleApi {
   async transportData(data: string): Promise<boolean> {
     this.logger.log(`call transportData (data: ${data})`);
     let result = true;
-    const envEmail = this.configService.getOrThrow<string>('googleApi.email');
-    const envKey = this.configService.getOrThrow<string>('googleApi.key');
-    const envSsid = this.configService.getOrThrow<string>(
-      'googleApi.spreadsheetId',
-    );
-    const envRange = this.configService.getOrThrow<string>('googleApi.range');
+    const envEmail = this.configService.get<string>('googleApi.email');
+    const envKey = this.configService.get<string>('googleApi.key');
+    const envSsid = this.configService.get<string>('googleApi.spreadsheetId');
+    const envRange = this.configService.get<string>('googleApi.range');
     try {
       const googleAuth = new auth.JWT({
         email: envEmail,


### PR DESCRIPTION
보안 + iOS 의 위젯 개발을 위해 refreshToken 을 추가하였습니다.

## 수정 및 작업 내용
1. env 값 추가
기존 env
```
JWT_EXPIREIN=
```
변경 후 env
```
JWT_ACCESS_EXPIREIN=
JWT_REFRESH_EXPIREIN=
```

2. httpOnly 설정
기존의 accessToken 은 쿠키에 담겨 있으며, 옵션은 다음과 같았습니다.
```
const cookieOptions = {
      expires: <기존의 accessToken 만료 값>,
      httpOnly: false,
      domain,
};
```
accessToken 은 기존과 동일하게 두고, refreshToken 은 httpOnly 옵션을 true 로 추가하여 작업하였습니다.

3. accessToken 재발급 api
/user/login 의 인증/인가 관련 api에 
/refresh 라는 POST 요청을 하나 제작하였습니다.
access 토큰이 만료되었을 때 refresh 토큰을 이용해 새로운 access 토큰을 생성합니다.
refresh 또한 만료되어있는 경우 status code 401을 반환합니다.

4. 만료 기간을 설정하는 위치 변경
기존에는 authModule 에서 jwtModule 을 import 하는 곳에서 만료 기간을 함께 설정했는데,
controller 에서 토큰을 생성하기 전 env 값을 가져와 설정하도록 바뀌었습니다.

5. jwtService 내 사용하는 메서드 변경
decode -> verify -> verifyAsync
sign -> signAsync

6. 프론트와의 충돌 여부 검사
변경된 백엔드 + 기존의 프론트 -> 기존처럼 엑세스 토큰만 동작
변경된 백엔드 + 변경된 프론트 -> 리프레시 토큰 작동

7. `.env.sample` 파일 수정
jwt 토큰 만료 값에 대한 설명과 같이 기존에 빠져있던 항목도 추가하였습니다.

8. env 값을 가져오는 부분 변경
필수가 아닌 항목에 대해 `getOrThrow` -> `get` 로 변경하였습니다.

## 테스트 방법
1. 백엔드 feat/refreshToken 브랜치로 변경
2. 백엔드 env 설정
```
URL_FOR_CORS = <로컬 프론트와 맞춰주기>
```
3. 프론트 코드 클론
https://github.com/niamu01/24hane-frontend
4. 프론트 env 설정 
```
  VITE_APP_API_URL= <로컬 백엔드와 맞춰주기>
  VITE_TOKEN="accessToken" # 기존 코드 실행 시
  VITE_ACCESS_TOKEN="accessToken" # 수정된 프론트 코드 실행 시
  VITE_REFRESH_TOKEN="refreshToken" # 수정된 프론트 코드 실행 시
```
5. 프론트 실행
6. 백엔드 실행 (도커 & app 둘 다)
7. `localhost:프론트포트` 접속
8. 쿠키 확인
![스크린샷 2024-07-16 오후 10 08 21](https://github.com/user-attachments/assets/e819cb69-9b98-4997-8587-73f6fb48b738)
*7/16에 `accessToken = 1d`, `refreshToken = 28d` 로 실행한 결과

## 시퀀스 다이어그램
```mermaid
sequenceDiagram
    actor User
    participant R as Frontend (Vue)
    participant A as Frontend (Axios)
    participant AS as Backend (NestJS Server)
    participant FO as 42 OAuth

    User->>R: 로그인 페이지 접근
    R->>User: 로그인 페이지 표시

    User->>AS: GET /user/login/42(?redirect=/auth)
    AS->>FO: 42 OAuth 인증 요청
    FO-->>User: 사용자 인증 페이지
    User->>FO: 사용자 인증
    FO-->>AS: 42 인증 코드 전달
    AS->>AS: JWT 토큰 생성 (access, refresh)
    AS-->>User: JWT 토큰 쿠키 설정 (callback)

    Note over User,AS: 로그인 완료

    User->>R: 보호된 라우트 접근 (/home)
    R->>A: 요청 인터셉터 (토큰 확인)
    A->>AS: API 요청 (with Access Token)
    AS-->>A: 응답
    A-->>R: 응답
    R-->>User: 페이지 표시

    Note over User,AS: Access Token 만료

    User->>R: 보호된 라우트 접근 (/home)
    R->>A: 요청 인터셉터 (토큰 확인)
    A->>AS: API 요청 (with 만료된 토큰)
    AS-->>A: 401 Unauthorized
    A->>AS: POST /user/login/refresh (with Refresh Token)
    AS->>AS: 새 Access Token 생성
    AS-->>A: 새 Access Token
    A->>A: 토큰 갱신 및 재요청
    A->>AS: 원래 API 요청 (새 토큰)
    AS-->>A: 응답
    A-->>R: 응답
    R-->>User: 페이지 표시

    Note over User,AS: 로그아웃

    User->>R: 로그아웃 요청
    R->>User: 토큰 삭제 (쿠키, 로컬스토리지)
    R->>User: 로그인 페이지로 리다이렉트
```